### PR TITLE
Linux 4.14 fix: use kernel_read/kernel_write for linux 4.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Many usb Wi-Fi adapters that claim to have an RT5370 chipset actually have an MT
 - 3.12.35 (Raspberry Pi)
 - 3.18.16 (Raspberry Pi)
 - 4.4.12 (Raspberry Pi)
+- 4.14.15 (Orange Pi Pc)
 
 Please note that this kernel will only work properly on 32 bits. It will crash on 64 bits.
 

--- a/os/linux/config.mk
+++ b/os/linux/config.mk
@@ -184,6 +184,8 @@ STRIP := $(CROSS_COMPILE)strip
 
 WFLAGS := -DAGGREGATION_SUPPORT -DPIGGYBACK_SUPPORT -DWMM_SUPPORT -DLINUX -Wall -Wstrict-prototypes -Wno-trigraphs
 WFLAGS += -DSYSTEM_LOG_SUPPORT -DRT28xx_MODE=$(RT28xx_MODE) -DCHIPSET=$(MODULE) -DRESOURCE_PRE_ALLOC
+WFLAGS += -Wno-error=date-time
+WFLAGS += -Wno-error=incompatible-pointer-types
 #WFLAGS += -DFPGA_MODE
 WFLAGS += -I$(RT28xx_DIR)/include
 

--- a/os/linux/rt_linux.c
+++ b/os/linux/rt_linux.c
@@ -898,7 +898,11 @@ int RtmpOSFileRead(RTMP_OS_FD osfd, char *pDataPtr, int readLen)
 
 	/* The object must have a read method */
 	if (osfd->f_op) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0)
 		return vfs_read(osfd, pDataPtr, readLen, &osfd->f_pos);
+#else
+		return kernel_read(osfd, pDataPtr, readLen, &osfd->f_pos);
+#endif
 	} else {
 		DBGPRINT(RT_DEBUG_ERROR, ("no file read method\n"));
 		return -1;
@@ -907,7 +911,11 @@ int RtmpOSFileRead(RTMP_OS_FD osfd, char *pDataPtr, int readLen)
 
 int RtmpOSFileWrite(RTMP_OS_FD osfd, char *pDataPtr, int writeLen)
 {
-	return osfd->f_op->write(osfd, pDataPtr, (size_t) writeLen, &osfd->f_pos);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0)
+	return vfs_write(osfd, pDataPtr, (size_t) writeLen, &osfd->f_pos);
+#else
+	return kernel_write(osfd, pDataPtr, (size_t) writeLen, &osfd->f_pos);
+#endif
 }
 
 static inline void __RtmpOSFSInfoChange(OS_FS_INFO * pOSFSInfo, BOOLEAN bSet)

--- a/os/linux/rt_linux.c
+++ b/os/linux/rt_linux.c
@@ -894,9 +894,11 @@ void RtmpOSFileSeek(RTMP_OS_FD osfd, int offset)
 
 int RtmpOSFileRead(RTMP_OS_FD osfd, char *pDataPtr, int readLen)
 {
+	DBGPRINT(RT_DEBUG_ERROR, ("add: %p %p\n", osfd->f_op, osfd->f_op->read));
+
 	/* The object must have a read method */
-	if (osfd->f_op && osfd->f_op->read) {
-		return osfd->f_op->read(osfd, pDataPtr, readLen, &osfd->f_pos);
+	if (osfd->f_op) {
+		return vfs_read(osfd, pDataPtr, readLen, &osfd->f_pos);
 	} else {
 		DBGPRINT(RT_DEBUG_ERROR, ("no file read method\n"));
 		return -1;


### PR DESCRIPTION
kernel_read/kernel_write was exported in linux 3.9,before linux 3.9 use vfs_read/vfs_write